### PR TITLE
Support es256 OIDC key alg

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -1076,7 +1076,7 @@ func (serve *Serve) validateJwt(token *jwt.Token, unparsedToken string, idp *idp
 		return trySpecificPublicKeys(unparsedToken, idp.rsaKeys, serve)
 	}
 
-	if strings.HasPrefix(token.Method.Alg(), "EC") {
+	if (strings.HasPrefix(token.Method.Alg(), "EC") || strings.HasPrefix(token.Method.Alg(), "ES")) {
 		return trySpecificPublicKeys(unparsedToken, idp.ecdsaKeys, serve)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,3 @@
-# github.com/golang-jwt/jwt/v5 v5.2.0
+# github.com/golang-jwt/jwt/v5 v5.2.1
 ## explicit; go 1.18
 github.com/golang-jwt/jwt/v5


### PR DESCRIPTION
Hi,
I appreciate this small  OIDC plugin. I use it with Kanidm as IDM (http://kanidm.com). Its default key type is ES256 (SCDSA with SHA-256  if I understand this correctly).

This patch handles the ES256 key alg as ecdsa, and authentication can succeed correctly. It works for me, in my lab setup.
Let me know If I should do some more testing etc.

Best,
Erich